### PR TITLE
expect that devise_type is a symobol

### DIFF
--- a/lib/rack/user_agent/result.rb
+++ b/lib/rack/user_agent/result.rb
@@ -2,6 +2,7 @@ module Rack
   class UserAgent
     module Result
       def device_type
+        return :UNKNOWN if woothee_result[:category] == Woothee::VALUE_UNKNOWN
         woothee_result[:category]
       end
 

--- a/spec/lib/rack/user_agent/result_spec.rb
+++ b/spec/lib/rack/user_agent/result_spec.rb
@@ -28,4 +28,17 @@ describe "Rack::UserAgent::Result" do
       last_request.public_send(method).must_equal woothee_result[original]
     end
   end
+
+  describe "UNKNOWN category" do
+    let(:ua) { "ELB-HealthChecker/1.0" }
+
+    it "device_type should return symbol" do
+      header "User-Agent", ua
+      get "/"
+
+      woothee_result[:category].must_equal Woothee::VALUE_UNKNOWN
+      last_request.device_type.must_equal Woothee::VALUE_UNKNOWN.to_sym
+      last_request.device_type.class.must_equal Symbol
+    end
+  end
 end


### PR DESCRIPTION
In Rails usage, `request.variant` assigns `request.device_type` directly.

https://github.com/k0kubun/rack-user_agent#rails

``` rb
 request.variant = request.device_type # :pc, :smartphone
```

If `device_type` is unknown, rails returned ArgumentError.

```
ArgumentError (request.variant must be set to a Symbol or an Array of Symbols, not a String. For security reasons, never directly set the variant to a user-provided value, like params[:variant].to_sym. Check user-provided value against a whitelist first, then set the variant: request.variant = :tablet if params[:variant] == 'tablet'):
```

Because woothee returns string.

https://github.com/woothee/woothee-ruby/blob/master/lib/woothee.rb#L153

``` rb
  FILLED = {
    Woothee::ATTRIBUTE_NAME => Woothee::VALUE_UNKNOWN,
    Woothee::ATTRIBUTE_CATEGORY => Woothee::VALUE_UNKNOWN,
    Woothee::ATTRIBUTE_OS => Woothee::VALUE_UNKNOWN,
    Woothee::ATTRIBUTE_OS_VERSION => Woothee::VALUE_UNKNOWN,
    Woothee::ATTRIBUTE_VERSION => Woothee::VALUE_UNKNOWN,
    Woothee::ATTRIBUTE_VENDOR => Woothee::VALUE_UNKNOWN,
  }.freeze
  def self.fill_result(result)
    FILLED.merge(result)
  end
```

https://github.com/woothee/woothee-ruby/blob/master/lib/woothee/dataset.rb#L30
`VALUE_UNKNOWN = "UNKNOWN"`

I challenge a patch. 
But this is wrong that lock in rails.
Do you have any idea?
