### PR TITLE
Add `from ipod?` to Detectors

### DIFF
--- a/lib/rack/user_agent/detector.rb
+++ b/lib/rack/user_agent/detector.rb
@@ -20,6 +20,10 @@ module Rack
         os == "iPad"
       end
 
+      def from_ipod?
+        os == "iPod"
+      end
+
       def from_android?
         os == "Android" && android_mobile?
       end

--- a/spec/lib/rack/user_agent/detector_spec.rb
+++ b/spec/lib/rack/user_agent/detector_spec.rb
@@ -28,6 +28,13 @@ describe "Rack::UserAgent::Detector" do
       ]
     },
     {
+      name: "iPod",
+      version: "8.0",
+      user_agents: [
+        "Mozilla/5.0 (iPod touch; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A365 Safari/600.1.4"
+      ]
+    },
+    {
       name: "Android",
       version: "4.0.1",
       user_agents: [
@@ -125,6 +132,16 @@ describe "Rack::UserAgent::Detector" do
         header "User-Agent", ua
         get "/"
         last_request.from_ipad?.must_equal true
+      end
+    end
+  end
+
+  describe "#from_ipod?" do
+    it "returns true if the request comes from ipod" do
+      user_agents("iPod").each do |ua|
+        header "User-Agent", ua
+        get "/"
+        last_request.from_ipod?.must_equal true
       end
     end
   end


### PR DESCRIPTION
# What's this pull request

`request is iPod ?` Clear
## before

``` ruby
def request_is_smartphone?
  request.from_iphone? || request.os == 'iPod'
end
```
## after

``` ruby
def request_is_smartphone?
  request.from_iphone? || request.from_ipod?
end
```
