### PR TITLE
Support rack 2.x

### DIFF
--- a/rack-user_agent.gemspec
+++ b/rack-user_agent.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rack", "~> 1.5"
+  spec.add_dependency "rack", ">= 1.5"
   spec.add_dependency "woothee", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
This gem doesn't work on Rails 5 since Rails 5 depends on rack 2.x https://github.com/rails/rails/blob/v5.0.0.beta1/actionpack/actionpack.gemspec

Can we loosen the version restriction here?
