### PR TITLE
Rails 5 doesn't rack ActionDispatch::ParamsParser

### DIFF
--- a/lib/rack/user_agent/railtie.rb
+++ b/lib/rack/user_agent/railtie.rb
@@ -2,7 +2,7 @@ module Rack
   class UserAgent
     class Railtie < ::Rails::Railtie
       initializer "rack-user_agent.configure_rails_initialization" do |app|
-        app.config.middleware.insert_before(ActionDispatch::ParamsParser, Rack::UserAgent)
+        app.config.middleware.insert_after(Rack::Head, Rack::UserAgent)
       end
     end
   end


### PR DESCRIPTION
Rails 5 app + rack-user_agent fails to boot because Rails 5 doesn't have AD::ParamsParser in its middleware stack since https://github.com/rails/rails/commit/38d2bf5fd1f3e014f2397898d371c339baa627b1.

TBH I don't really understand why we're inserting Rack::UserAgent middleware before ParamsParser, but inserting it after Rack::Head might be the way to rack it at the exactly same place on Rails 4 && support Rails 5.

FYI pasted below are the results of `rake middleware` from 4.2 and 5.0 vanilla apps.

```
#4.2.5
use Rack::Sendfile
use ActionDispatch::Static
use Rack::Lock
use #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x007f9025c346c0>
use Rack::Runtime
use Rack::MethodOverride
use ActionDispatch::RequestId
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use WebConsole::Middleware
use ActionDispatch::DebugExceptions
use ActionDispatch::RemoteIp
use ActionDispatch::Reloader
use ActionDispatch::Callbacks
use ActiveRecord::Migration::CheckPending
use ActiveRecord::ConnectionAdapters::ConnectionManagement
use ActiveRecord::QueryCache
use ActionDispatch::Cookies
use ActionDispatch::Session::CookieStore
use ActionDispatch::Flash
use ActionDispatch::ParamsParser
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
run R42Tes::Application.routes
```

```
#5.0.0.beta1
use Rack::Sendfile
use ActionDispatch::Static
use ActionDispatch::LoadInterlock
use ActiveSupport::Cache::Strategy::LocalCache::Middleware
use Rack::Runtime
use Rack::MethodOverride
use ActionDispatch::RequestId
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use WebConsole::Middleware
use ActionDispatch::DebugExceptions
use ActionDispatch::RemoteIp
use ActionDispatch::Reloader
use ActionDispatch::Callbacks
use ActiveRecord::Migration::CheckPending
use ActiveRecord::ConnectionAdapters::ConnectionManagement
use ActiveRecord::QueryCache
use ActionDispatch::Cookies
use ActionDispatch::Session::CookieStore
use ActionDispatch::Flash
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
use ActionView::Digestor::PerRequestDigestCacheExpiry
run R5Tes::Application.routes
```
