### PR TITLE
ActionDispatch::Request is not < Rack::Request in Rails 5

### DIFF
--- a/lib/rack/user_agent/railtie.rb
+++ b/lib/rack/user_agent/railtie.rb
@@ -3,6 +3,14 @@ module Rack
     class Railtie < ::Rails::Railtie
       initializer "rack-user_agent.configure_rails_initialization" do |app|
         app.config.middleware.insert_after(Rack::Head, Rack::UserAgent)
+
+        ActiveSupport.on_load(:action_controller) do
+          ActionDispatch::Request.class_eval do
+            include Rack::UserAgent::Checker
+            include Rack::UserAgent::Detector
+            include Rack::UserAgent::Result
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/529136d670c46bd66b56c519d4f51ed8f86c75b1.

I'm sorry that I couldn't PR all those Rails 5 fixes all together, but I hope this to be the last one.
