### PR TITLE
Add methods to detect os

### DIFF
--- a/lib/rack/user_agent/detector.rb
+++ b/lib/rack/user_agent/detector.rb
@@ -24,12 +24,20 @@ module Rack
         os == "iPod"
       end
 
+      def from_ios?
+        from_iphone? || from_ipad? || from_ipod?
+      end
+
       def from_android?
         os == "Android" && android_mobile?
       end
 
       def from_android_tablet?
         os == "Android" && !android_mobile?
+      end
+
+      def from_android_os?
+        from_android? || from_android_tablet?
       end
 
       def from_windows_phone?

--- a/spec/lib/rack/user_agent/detector_spec.rb
+++ b/spec/lib/rack/user_agent/detector_spec.rb
@@ -8,6 +8,7 @@ describe "Rack::UserAgent::Detector" do
   SMARTPHONES = [
     {
       name: "iPhone",
+      os: "iOS",
       version: "5.1.1",
       user_agents: [
         "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3",
@@ -15,6 +16,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "iPhone",
+      os: "iOS",
       version: "6.0",
       user_agents: [
         "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A403 Safari/8536.25",
@@ -22,6 +24,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "iPad",
+      os: "iOS",
       version: "6.0",
       user_agents: [
         "Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A403 Safari/8536.25"
@@ -29,6 +32,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "iPod",
+      os: "iOS",
       version: "8.0",
       user_agents: [
         "Mozilla/5.0 (iPod touch; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A365 Safari/600.1.4"
@@ -36,6 +40,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "Android",
+      os: "Android",
       version: "4.0.1",
       user_agents: [
         "Mozilla/5.0 (Linux; U; Android 4.0.1; ja-jp; Galaxy Nexus Build/ITL41D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
@@ -43,6 +48,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "Android",
+      os: "Android",
       version: "4.2.1",
       user_agents: [
         "Opera/9.80 (Android 4.2.1; Linux; Opera Mobi/ADR-1301080958) Presto/2.11.355 Version/12.10"
@@ -50,6 +56,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "Android",
+      os: "Android",
       version: nil,
       user_agents: [
         "Mozilla/5.0 (Android; Mobile; rv:18.0) Gecko/18.0 Firefox/18.0",
@@ -57,6 +64,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "Android Tablet",
+      os: "Android",
       version: "4.1.1",
       user_agents: [
         "Mozilla/5.0 (Linux; Android 4.1.1; Nexus 7 Build/JRO03S) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19"
@@ -64,6 +72,7 @@ describe "Rack::UserAgent::Detector" do
     },
     {
       name: "Windows Phone",
+      os: "Windows Phone",
       version: "7.5",
       user_agents: [
         "Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; FujitsuToshibaMobileCommun; IS12T; KDDI)"
@@ -146,6 +155,16 @@ describe "Rack::UserAgent::Detector" do
     end
   end
 
+  describe "#from_ios?" do
+    it "returns true if the request comes from ios" do
+      user_agents("iOS", key: :os).each do |ua|
+        header "User-Agent", ua
+        get "/"
+        last_request.from_ios?.must_equal true
+      end
+    end
+  end
+
   describe "#from_android?" do
     it "returns true if the request comes from android mobile" do
       user_agents("Android").each do |ua|
@@ -166,6 +185,16 @@ describe "Rack::UserAgent::Detector" do
     end
   end
 
+  describe "#from_android_os?" do
+    it "returns true if the request comes from android os" do
+      user_agents("Android", key: :os)  .each do |ua|
+        header "User-Agent", ua
+        get "/"
+        last_request.from_android_os?.must_equal true
+      end
+    end
+  end
+
   describe "#from_windows_phone?" do
     it "returns true if the request comes from windows phone" do
       user_agents("Windows Phone").each do |ua|
@@ -176,7 +205,8 @@ describe "Rack::UserAgent::Detector" do
     end
   end
 
-  def user_agents(name)
-    SMARTPHONES.find { |info| info[:name] == name }[:user_agents]
+  def user_agents(word, key: :name)
+    SMARTPHONES.find_all { |info| info[key] == word }
+      .flat_map { |info| info[:user_agents]}
   end
 end


### PR DESCRIPTION
Is it useful for you to detect OS? 🔍 

``` ruby
if request.from_iphone? || request.from_ipad? || request.from_ipod? # => request.from_ios?
  ...
end
```

FYI `user_agents` should return _all_ user agents?
