### PR TITLE
Detect as 'from_ios' when os is iOS

### DIFF
--- a/lib/rack/user_agent/detector.rb
+++ b/lib/rack/user_agent/detector.rb
@@ -25,7 +25,7 @@ module Rack
       end
 
       def from_ios?
-        from_iphone? || from_ipad? || from_ipod?
+        from_iphone? || from_ipad? || from_ipod? || os == "iOS"
       end
 
       def from_android?

--- a/spec/lib/rack/user_agent/detector_spec.rb
+++ b/spec/lib/rack/user_agent/detector_spec.rb
@@ -39,6 +39,14 @@ describe "Rack::UserAgent::Detector" do
       ]
     },
     {
+      name: "UNKNOWN",
+      os: "iOS",
+      version: nil,
+      user_agents: [
+        "Blogos/1.13 CFNetwork/548.0.4 Darwin/11.0.0"
+      ]
+    },
+    {
       name: "Android",
       os: "Android",
       version: "4.0.1",


### PR DESCRIPTION
https://github.com/vividmuimui/woothee/blob/v1.4.0/testsets/smartphone_ios.yaml#L93-L96

``` yaml
- target: 'Blogos/1.13 CFNetwork/548.0.4 Darwin/11.0.0'
  name: UNKNOWN
  os: iOS
  category: smartphone
```

in this case, `#from_ios?` is `false`. So fix it.
