### PR TITLE
Support woothee 1.1+

### DIFF
--- a/rack-user_agent.gemspec
+++ b/rack-user_agent.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rack", ">= 1.5"
-  spec.add_dependency "woothee", "~> 1.0.0"
+  spec.add_dependency "woothee", ">= 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This gem depends on woothee "~> 1.0.0" but woothee already has so many releases beyond 1.1
https://github.com/woothee/woothee-ruby/compare/v1.0.1...master
