### PR TITLE
Add/Remove Ruby versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.3.4
-  - 2.4.1
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,8 @@ rvm:
 branches:
   only:
     - master
+before_install:
+  - travis_retry gem update --system || travis_retry gem update --system 2.7.8
+  - travis_retry gem install bundler --no-document || travis_retry gem install bundler --no-document -v 1.17.3
 script:
   - "bundle exec rake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.1.10
-  - 2.2.7
   - 2.3.4
   - 2.4.1
 branches:

--- a/rack-user_agent.gemspec
+++ b/rack-user_agent.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1.5"
   spec.add_dependency "woothee", ">= 1.0.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
I use this gem to own project. But the test is not run in newer ruby.
So I changed 3 points.

- remove rubies from ci (EOL versions)
    - 2.1.10
    - 2.2.7
- add rubies to ci
    - 2.5
    - 2.6
    - ruby-head (Should I set that to allow-failure?)
- change bundler version requirement to higher than 1.10