### PR TITLE
Restrict minitest version to lower than 6

### DIFF
--- a/rack-user_agent.gemspec
+++ b/rack-user_agent.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest", '~> 5'
   spec.add_development_dependency "rack-test"
 end


### PR DESCRIPTION
this gem's test uses syntax that will be removed in minitest
version 6.

## test that raises the waring message
https://github.com/k0kubun/rack-user_agent/blob/25c90dc801a953414ddabc2fc34064226df85b4c/spec/lib/rack/user_agent/detector_spec.rb#L130

> DEPRECATED: Use assert_nil if expecting nil from /home/unasuke/src/github.com/unasuke/rack-user_agent/spec/lib/rack/user_agent/detector_spec.rb:130. This will fail in Minitest 6.


## see also
- https://github.com/seattlerb/minitest/issues/666