### PR TITLE
Exclude sample directories from spec.files

### DIFF
--- a/rack-user_agent.gemspec
+++ b/rack-user_agent.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/k0kubun/rack-user_agent"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").grep_v(%r{sample/})
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
I'm having trouble with vulnerability alerts from [Amazon Inspector](https://aws.amazon.com/inspector/).
`rack-user_agent-0.5.2/rails_sample/Gemfile.lock` is alerted.

<img width="400" alt="WldNDMd6" src="https://user-images.githubusercontent.com/6626484/150647250-21519b70-12b4-4de8-b0e0-f01680bd449e.png">

----

This gem's package includes `rails_sample`,`sinatra_sample`.
But I think that is not library files.

```sh
$ ls -1 $(gem environment gemdir)/gems/rack-user_agent-0.5.2
CHANGELOG.md
Gemfile
LICENSE.txt
README.md
Rakefile
lib
rack-user_agent.gemspec
rails_sample
sinatra_sample
spec
```

So, I exclude sample directories from `spec.files`.


